### PR TITLE
ENG-23999: Chore/update omniauth oauth2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Style/BracesAroundHashParameters:
 
 # Indentation of `when`.
 Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
   SupportedStyles:
     - case
     - end
@@ -156,6 +156,10 @@ Metrics/MethodLength:
 
 Metrics/LineLength:
   Max: 120
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
 
 ##################### Lint ################################
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,15 @@
 # Copied from:
 # https://github.com/omniauth/omniauth/blob/master/.travis.yml
-bundler_args: --without development
-before_install: gem update bundler
+before_install:
+  - gem update --system
+  - gem update bundler
 cache: bundler
 env:
   global:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - jruby-9000
-  - 2.1.10 # EOL Soon
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-head
-  - ruby-head
+  - 2.5.1
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/Rakefile
+++ b/Rakefile
@@ -11,8 +11,8 @@ begin
   RuboCop::RakeTask.new
 rescue LoadError
   task :rubocop do
-    $stderr.puts 'RuboCop is disabled'
+    warn 'RuboCop is disabled'
   end
 end
 
-task :default => [:spec, :rubocop]
+task :default => %i[spec rubocop]

--- a/lib/omniauth-dotloop.rb
+++ b/lib/omniauth-dotloop.rb
@@ -1,3 +1,4 @@
 # rubocop:disable Style/FileName
 require 'omniauth-dotloop/version'
 require 'omniauth/strategies/dotloop'
+# rubocop:enable Style/FileName

--- a/lib/omniauth-dotloop/version.rb
+++ b/lib/omniauth-dotloop/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Dotloop
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.1.0'.freeze
   end
 end

--- a/lib/omniauth/strategies/dotloop.rb
+++ b/lib/omniauth/strategies/dotloop.rb
@@ -25,6 +25,14 @@ module OmniAuth
       info {}
 
       extra {}
+
+      private
+
+      # Overriding this method provided by OmniAuth::Strategies - we don't want the querystring appended to the callback_url
+      # See https://github.com/omniauth/omniauth-oauth2/issues/81
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/dotloop.rb
+++ b/lib/omniauth/strategies/dotloop.rb
@@ -28,7 +28,8 @@ module OmniAuth
 
       private
 
-      # Overriding this method provided by OmniAuth::Strategies - we don't want the querystring appended to the callback_url
+      # Overriding this method provided by OmniAuth::Strategies
+      #   we don't want the querystring appended to the callback_url
       # See https://github.com/omniauth/omniauth-oauth2/issues/81
       def callback_url
         full_host + script_name + callback_path

--- a/omniauth-dotloop.gemspec
+++ b/omniauth-dotloop.gemspec
@@ -15,8 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w(lib)
   gem.version       = OmniAuth::Dotloop::VERSION
 
-  # Lock at 1.3.x due to https://github.com/intridea/omniauth-oauth2/issues/81
-  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'

--- a/omniauth-dotloop.gemspec
+++ b/omniauth-dotloop.gemspec
@@ -1,4 +1,4 @@
-require File.expand_path('../lib/omniauth-dotloop/version', __FILE__)
+require File.expand_path('lib/omniauth-dotloop/version', __dir__)
 
 Gem::Specification.new do |gem|
   gem.authors       = 'Contactually'
@@ -6,13 +6,13 @@ Gem::Specification.new do |gem|
   gem.description   = 'OmniAuth OAuth2 strategy for Contactually.'
   gem.summary       = gem.description
   gem.homepage      = 'https://github.com/dotloop/omniauth-dotloop'
-  gem.licenses      = %w(MIT)
+  gem.licenses      = %w[MIT]
 
   gem.executables   = `git ls-files -- bin/*`.split("\n").collect { |f| File.basename(f) }
   gem.files         = `git ls-files`.split("\n")
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = 'omniauth-dotloop'
-  gem.require_paths = %w(lib)
+  gem.require_paths = %w[lib]
   gem.version       = OmniAuth::Dotloop::VERSION
 
   gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-$LOAD_PATH.unshift File.expand_path('..', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path(__dir__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'rspec'
 require 'rack/test'


### PR DESCRIPTION
The main reason for updating this gem is to be able to bump omniauth-google-oauth2 to 0.6.0 which removes hitting the deprecated Google+ APIs

In order to do this, we needed to bump the lock version of `omniauth-oauth2` to `1.6.0`

To fix the issues we were band-aiding with version 1.3.1 of `omniauth-oauth2` is explained below:

Override callback_url method provided by OmniAuth::Strategies

`omniauth-oauth2` 1.4.0 removed overriding this method itself - this
caused an issue where the callback_url was not exactly matching what the
provider (dotloop) expects and returning an error during the oauth
authentication process.

The `omniauth` gem appends any `querystring` value to the callback_url
which is sort of OAuth 2.0 spec compliant but the spec is vague so
having the querystring in the callback url isn't hard defined - hence
the differences between providers.

In any case, dotloop wants no querystring in the callback url so we
override the method here to remove the querystring


Can see the origins of the issue here:
See https://github.com/omniauth/omniauth-oauth2/issues/81